### PR TITLE
Removed unused imports from all python files

### DIFF
--- a/demos_urbansim/agetest.py
+++ b/demos_urbansim/agetest.py
@@ -3,11 +3,6 @@ orca.add_injectable('all_local', True)
 orca.add_injectable('region_code', '06197001')
 orca.add_injectable('calibrated_folder', 'custom')
 orca.add_injectable('running_calibration_routine', False)
-import datasources
-import variables
-import update_demos
-import sys
-import pandas as pd
 
 
 

--- a/demos_urbansim/checkHouses.py
+++ b/demos_urbansim/checkHouses.py
@@ -3,7 +3,6 @@ orca.add_injectable('all_local', True)
 orca.add_injectable('region_code', '06197001')
 orca.add_injectable('calibrated_folder', 'custom')
 orca.add_injectable('running_calibration_routine', False)
-import datasources
 
 
 persons = orca.get_table('persons').to_frame()

--- a/demos_urbansim/datasources.py
+++ b/demos_urbansim/datasources.py
@@ -8,9 +8,7 @@ import orca
 import pandas as pd
 import yaml
 from google.cloud import storage
-from urbansim_templates import modelmanager as mm
 from urbansim_templates.data import LoadTable
-from urbansim_templates.models import LargeMultinomialLogitStep, OLSRegressionStep
 
 print("importing datasources")
 

--- a/demos_urbansim/fatalityTest.py
+++ b/demos_urbansim/fatalityTest.py
@@ -4,10 +4,6 @@ orca.add_injectable('all_local', True)
 orca.add_injectable('region_code', '06197001')
 orca.add_injectable('calibrated_folder', 'custom')
 orca.add_injectable('running_calibration_routine', False)
-import datasources
-import variables
-
-import update_demos
 
 person_df = orca.get_table('persons').to_frame()
 person_df.sort_values('household_id', inplace=True)

--- a/demos_urbansim/indicators.py
+++ b/demos_urbansim/indicators.py
@@ -1,4 +1,3 @@
-import os
 import orca
 import yaml
 import json

--- a/demos_urbansim/initr.py
+++ b/demos_urbansim/initr.py
@@ -3,7 +3,3 @@ orca.add_injectable('all_local', True)
 orca.add_injectable('region_code', '06197001')
 orca.add_injectable('calibrated_folder', 'custom')
 orca.add_injectable('running_calibration_routine', False)
-import datasources
-import variables
-import update_demos
-

--- a/demos_urbansim/marriage.py
+++ b/demos_urbansim/marriage.py
@@ -1,4 +1,3 @@
-import orca
 import pandas as pd
 
 

--- a/demos_urbansim/personsLength.py
+++ b/demos_urbansim/personsLength.py
@@ -4,9 +4,6 @@ orca.add_injectable('all_local', True)
 orca.add_injectable('region_code', '06197001')
 orca.add_injectable('calibrated_folder', 'custom')
 orca.add_injectable('running_calibration_routine', False)
-import datasources
-import variables
-import update_demos
 
 #Length of persons: 6802465
 print(orca.get_table('persons').to_frame(columns='(Intercept)'))

--- a/demos_urbansim/plotting.py
+++ b/demos_urbansim/plotting.py
@@ -1,10 +1,7 @@
 """Plot average trips on weekdays by hour of day for dry and wet weather.
 """
-import sys
-import os
 import argparse
 
-import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
 import seaborn as sns

--- a/demos_urbansim/process_skims.py
+++ b/demos_urbansim/process_skims.py
@@ -1,5 +1,4 @@
 import pandas as pd
-import geopandas
 
 beam_skims_types = {'timePeriod': str,'pathType': str,'origin': int,'destination': int,'TIME_minutes': float, 'TOTIVT_IVT_minutes': float, 'VTOLL_FAR': float, 'DIST_meters': float, 'WACC_minutes': float, 'WAUX_minutes': float, 'WEGR_minutes': float, 'DTIM_minutes': float, 'DDIST_meters': float, 'KEYIVT_minutes': float, 'FERRYIVT_minutes': float, 'BOARDS': float, 'DEBUG_TEXT': str}
 

--- a/demos_urbansim/simulate.py
+++ b/demos_urbansim/simulate.py
@@ -125,4 +125,3 @@ if __name__ == '__main__':
     # breakpoint()
     # uid = pwd.getpwnam(usernmae).pw_uid
     # gid = grp.getgrnam(groupname).gr_gid
-    os.chown(output_fname, uid, gid)

--- a/demos_urbansim/simulate.py
+++ b/demos_urbansim/simulate.py
@@ -3,9 +3,7 @@ import os
 
 import numpy as np
 import orca
-import pandas as pd
 from urbansim_templates import modelmanager as mm
-from urbansim_templates.models import LargeMultinomialLogitStep, OLSRegressionStep
 
 
 def run(

--- a/demos_urbansim/variables.py
+++ b/demos_urbansim/variables.py
@@ -3,7 +3,6 @@ from collections import OrderedDict
 
 import mode_choice
 import numpy as np
-import openmatrix as omx
 import orca
 import pandas as pd
 import yaml


### PR DESCRIPTION
This PR removes all unused imports from the python files using VSCode and Flake8 to identify imports that are unused. I ran the simulation and didn't notice any issues, but please test this branch on your end and let me know if you have any concerns!

Closes #6 